### PR TITLE
Fix problem which can't enable pbcopy on OSX

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -70,9 +70,7 @@ set-environment -gu RBENV_VERSION
 bind C-@ copy-mode
 bind C-y paste-buffer
 # クリップボード共有
-# reattach-to-user-namespace は OSXでしか使えないので OSX固有設定の読み込み
-if-shell "uname | grep Darwin" "source-file ~/.tmux/.tmux.conf.osx" "" 
-bind-key -t emacs-copy C-@ begin-selection
+set-option -g default-command "reattach-to-user-namespace -l zsh 2> /dev/null || zsh"
 # C-rで読み込み
 bind r source-file ~/.tmux.conf\; display-message "Reload Config!!"
 # マウス

--- a/.tmux/.tmux.conf.osx
+++ b/.tmux/.tmux.conf.osx
@@ -1,7 +1,0 @@
-# OSX 固有設定 reattach-to-user-namespace
-bind-key -t emacs-copy M-w copy-pipe "reattach-to-user-namespace pbcopy"
-# Update default binding of `Enter` to also use copy-pipe
-unbind -t vi-copy Enter
-bind-key -t vi-copy Enter copy-pipe "reattach-to-user-namespace pbcopy"''""
-# pbcopy / pbpaste の有効化
-set-option -g default-command "reattach-to-user-namespace -l zsh"


### PR DESCRIPTION
OSX のtmux上でpbcopyでコピーしたものをクリップボードに渡す機能を追加しました.なお他のOS上での挙動を確認していないためそれを確認する
