### PR TITLE
CI 環境の更新

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
       os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - uses: actions/setup-python@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,10 +3,9 @@ on: push
 
 jobs:
   unit-test:
-    runs-on: ubuntu-latest
     strategy:
-      matrix:
-        python-version: [3.x, 2.x]
+      os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.x
       - name: display python version
         run: python -c "import sys; print(sys.version)"
       - name: execute test


### PR DESCRIPTION
# 概要

- CI で Python 2 のテストを削除
- CI で macOS でも確認する
- actions プラグインの更新
    - actions/checkout
    - actions/setup-python