### PR TITLE
find コマンドの広範囲実行を防ぐ PreToolUse フックを追加

### DIFF
--- a/claude/find-guard.sh
+++ b/claude/find-guard.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# PreToolUse hook (Bash matcher)
+#
+# find コマンドが範囲を指定せず(例: `find /`, `find ~`)に実行され、
+# CPU/Disk IO を大量消費するのを防ぐためのガード。
+#
+# 対象パスがルート直下・ホーム全体・OS 主要ディレクトリ全体などの
+# "広すぎる" パスで、かつ -maxdepth 指定がない場合のみ、
+# permissionDecision: ask を返して確認を挟む。
+# それ以外(スコープが絞られている find)には一切介入しない。
+
+set -euo pipefail
+
+input="$(cat)"
+cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
+
+[ -z "$cmd" ] && exit 0
+
+# "find" がコマンドとして呼ばれているか(先頭 or ; & | && || の後に find)
+if ! printf '%s' "$cmd" | grep -qE '(^|[;&|]|&&|\|\|)[[:space:]]*find([[:space:]]|$)'; then
+  exit 0
+fi
+
+# find の直後にある最初のパス引数(/ ~ $HOME で始まるもの)を抽出
+# (該当なしなら grep が非ゼロ終了するが、pipefail 環境でも落ちないよう || true で吸収)
+path="$(printf '%s' "$cmd" | grep -oE 'find[[:space:]]+(/[^[:space:]]*|~[^[:space:]]*|\$HOME[^[:space:]]*)' | head -1 | awk '{print $2}' || true)"
+
+[ -z "${path:-}" ] && exit 0
+
+# ルート直下・ホーム全体・OS 主要ディレクトリなど「広すぎる」パスの判定
+broad_pattern='^(/|~/?|\$HOME/?|/(Users|home|System|Library|usr|var|opt|Applications|mnt|media|proc|sys|etc|bin|sbin)/?)$'
+
+if printf '%s' "$path" | grep -qE "$broad_pattern"; then
+  if ! printf '%s' "$cmd" | grep -q -- '-maxdepth'; then
+    reason="find の探索範囲が広すぎます(対象: ${path})。CPU/Disk IO を大量に消費するおそれがあります。-maxdepth を指定するか、対象ディレクトリをより具体的に絞ってください。"
+    jq -n --arg reason "$reason" \
+      '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "ask", permissionDecisionReason: $reason}}'
+  fi
+fi
+
+exit 0

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -119,6 +119,11 @@
           {
             "type": "command",
             "command": "rtk hook claude"
+          },
+          {
+            "type": "command",
+            "command": "bash ~/.dotconfig/dotfiles/claude/find-guard.sh",
+            "timeout": 5
           }
         ]
       }
@@ -163,5 +168,7 @@
   "teammateMode": "tmux",
   "theme": "dark-ansi",
   "agentPushNotifEnabled": true,
-  "skipAutoPermissionPrompt": true
+  "skipAutoPermissionPrompt": true,
+  "effortLevel": "medium",
+  "model": "sonnet[1m]"
 }


### PR DESCRIPTION
## 概要
Claude Code が `find /` や `find ~` のような範囲を指定しない find を
無邪気に実行し、CPU/Disk IO を大量消費するのを防ぐための PreToolUse
フックを追加した。

## 変更内容
- `claude/find-guard.sh`(新規): Bash ツール呼び出しの `find` コマンドを
  解析し、対象パスが以下のいずれかで、かつ `-maxdepth` 指定がない場合
  のみ `permissionDecision: ask` を返して確認を挟む
  - `/`(ルート直下)
  - `~` / `$HOME`(ホームディレクトリ全体)
  - `/Users`, `/System`, `/Library`, `/usr`, `/var`, `/opt`,
    `/Applications`, `/etc` などOS主要ディレクトリ全体
  - スコープが絞られた検索や `-maxdepth` 付きの検索には介入しない
- `claude/settings.json`: 上記フックを既存の `PreToolUse` / `Bash`
  フック配列に追加(`rtk hook claude` と併用)。`effortLevel`,
  `model` の設定も追記
- `.zshrc`: `SSH_SK_PROVIDER`(libfido2)の環境変数を追加

## 検証
- パイプテストで危険系(`find /`, `find ~`, `find /Users`)は ask を
  返し、安全系(`find .`, `-maxdepth` 付きなど)は無介入であることを
  確認
- サンティネル方式で実際にフックが発火することを確認